### PR TITLE
Drop `autogen.sh`

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -27,6 +27,6 @@ srpm:
 	# (2.4.4-0.202204031154.git300480e.fc35).
 	git config --global --add safe.directory "$(shell pwd)"
 
-	./autogen.sh --system
+	autoreconf -if
 	./configure
 	$(MAKE) srpm OUTDIR=$(outdir)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Perform build
         run: |
-          ./autogen.sh --system
+          autoreconf -if
           ./configure
           make rpm OUTDIR=${{ env.ARTIFACTS_DIR }}
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -54,7 +54,7 @@ Notes:
 
     git checkout v0.15.1
     git clean -dxf
-    ./autogen.sh --system
+    autoreconf -if
     ./configure
     make
     make rpm

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-autoreconf -if
-


### PR DESCRIPTION
`autogen.sh` was used in several places with a --system argument which was completely ignored, just wrapping `autoreconf -if`. Updated calls to `autogen.sh` with calls to `autoreconf`.