### PR TITLE
Refactor dropping distutils

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -14,16 +14,13 @@ dist-hook:
 	cp -R $(srcdir)/* $(distdir)/tmp
 	rm -f $(distdir)/tmp/ioprocess/config.py  # Must be regenerated
 	chmod -R a+rw $(distdir)/tmp
-	$(PYTHON) $(distdir)/tmp/setup.py --verbose sdist --dist-dir "`readlink -f $(distdir)`" --manifest "`readlink -f $(distdir)`/MANIFEST"
+	$(PYTHON) -m build --sdist --verbose --no-isolation --outdir "`readlink -f $(distdir)`"
 	rm -rf $(distdir)/tmp
 	tar -xvf $(distdir)/ioprocess-$(VERSION).tar* -C "$(distdir)" --strip-components=1
 	rm $(distdir)/ioprocess-$(VERSION).tar*
 
 install-data-local:
 	$(PYTHON) "$(srcdir)/setup.py" build -b "`readlink -f $(builddir)`" install --root "$(DESTDIR)/" --prefix "$(prefix)" clean -a
-
-uninstall-local:
-	rm -r `$(PYTHON) -c 'from distutils import sysconfig; print(sysconfig.get_python_lib(0,0,"$(DESTDIR)${prefix}"))'`/ioprocess*
 
 $(srcdir)/ioprocess/config.py: $(srcdir)/ioprocess/config.py.in
 	sed -e "s,[@]IOPROCESS_DIR[@],$(IOPROCESS_DIR),g" \

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -1,6 +1,6 @@
 import os
 
-from distutils.core import setup
+from setuptools import setup
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -11,6 +11,6 @@ setup(
     license="GNU GPLv2+",
     author='Saggi Mizrahi',
     author_email='ficoos@gmail.com',
-    url='github.com/ficoos/ioprocess',
+    url='https://github.com/ficoos/ioprocess',
     packages=['ioprocess'],
 )

--- a/ioprocess.spec.in
+++ b/ioprocess.spec.in
@@ -22,6 +22,8 @@ BuildRequires:	automake
 BuildRequires:	gcc
 BuildRequires:	glib2-devel
 BuildRequires:	python3-devel
+BuildRequires:	python3-setuptools
+BuildRequires:	python3-build
 BuildRequires:	yajl-devel
 
 Requires:	yajl


### PR DESCRIPTION
The `distutils` module has been deprecated in Python 3.10 and removed in Python 3.12.

Replacing it with `setuptools` and `build` packages.