### PR TITLE
Fix issue #5

### DIFF
--- a/src/ioprocess.c
+++ b/src/ioprocess.c
@@ -120,7 +120,7 @@ static void logfunc(const gchar *log_domain, GLogLevelFlags log_level,
     }
 
     buff_size = snprintf(NULL, 0, format, levelStr, log_domain, message);
-    buff = calloc(sizeof(char), buff_size + 1);
+    buff = malloc(buff_size + 1);
     if (buff) {
         // if we can't allocated the buffer we can't really log
         snprintf(buff, buff_size + 1, format, levelStr, log_domain, message);


### PR DESCRIPTION
Fix issue #5 by replacing `calloc` with `malloc` as there's no need to zero the buffer as it gets immediately overwritten by the call to `snprintf`.